### PR TITLE
Hotfixes for rewind function

### DIFF
--- a/scenes/control/player_camera.gd
+++ b/scenes/control/player_camera.gd
@@ -118,10 +118,14 @@ func _physics_process(delta: float) -> void:
 	if is_respawn:
 		respawn_multi -= respawn_decel * respawn_multi * delta
 	
-	cur_pos = cur_pos.lerp(new_pos, cur_lerp_speed * delta * respawn_multi)
-	cur_pos.y = lerpf(prev_pos.y, new_pos.y, cur_lerp_speed * delta * 0.5 * respawn_multi)
-	cur_pos_bw = cur_pos_bw.lerp(new_pos_bw, cur_lerp_speed * delta * respawn_multi)
-	cur_pos_bw.y = lerpf(prev_pos_bw.y, new_pos_bw.y, cur_lerp_speed * delta * 0.5 * respawn_multi)
+	var rewind_multi: float = 1.0
+	if target.in_rewind:
+		rewind_multi = 2.0
+	
+	cur_pos = cur_pos.lerp(new_pos, cur_lerp_speed * delta * respawn_multi * rewind_multi)
+	cur_pos.y = lerpf(prev_pos.y, new_pos.y, cur_lerp_speed * delta * 0.5 * respawn_multi * rewind_multi)
+	cur_pos_bw = cur_pos_bw.lerp(new_pos_bw, cur_lerp_speed * delta * respawn_multi * rewind_multi)
+	cur_pos_bw.y = lerpf(prev_pos_bw.y, new_pos_bw.y, cur_lerp_speed * delta * 0.5 * respawn_multi * rewind_multi)
 
 
 

--- a/scenes/vehicles/vehicle_4.gd
+++ b/scenes/vehicles/vehicle_4.gd
@@ -570,7 +570,7 @@ func set_do_damage() -> void:
 func update_rewind_state() -> void:
 	exited_rewind = false
 	
-	if is_cpu or is_network:
+	if !is_player or is_network:
 		in_rewind = false
 		return
 	
@@ -587,6 +587,10 @@ func update_rewind_state() -> void:
 		return
 	
 	if !started:
+		in_rewind = false
+		return
+	
+	if active_items.size() > 0:
 		in_rewind = false
 		return
 


### PR DESCRIPTION
* Save location when using an item that takes over control.
* Don't allow rewinding while an item has an effect on you.
* Stop camera from reversing while rewinding a section driven at high speed.